### PR TITLE
lock the a2a-sdk version to 0.2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ graph TD
 
 ### 💰 **Currency Agent** (Port 8080)  
 - **Skills**: `currency_exchange`, `financial_data`, `market_analysis`, `rate_conversion`
-- **Use Cases**: "Convert 100 USD to EUR", "What's the exchange rate?", "Historical rates"
+- **Use Cases**: "what is 10 USD to INR?", "What's the exchange rate?", "Historical rates"
 - **Integration**: Frankfurter API with LangGraph ReAct agent
 
 ### 🧮 **Math Agent** (Port 8081)
@@ -91,7 +91,7 @@ graph TD
 - **Python 3.10+** (required for A2A SDK compatibility)
 - **Node.js** (for ArgoCD MCP server)
 - **[uv](https://docs.astral.sh/uv/)** package manager
-- **API Keys** (Google Gemini or OpenAI)
+- **API Keys** (Google Gemini or OpenAI; for Google Gemini, ensure Gemini API is enabled under your Google Cloud project)
 
 ### 1. Install Dependencies
 ```bash
@@ -128,7 +128,7 @@ export NODE_TLS_REJECT_UNAUTHORIZED="0"  # If using self-signed certs
 cd orchestrator
 
 # Test intelligent routing
-uv run -m app -m "Convert 100 USD to EUR" -v
+uv run -m app -m "what is 10 USD to INR?" -v
 uv run -m app -m "What is 2+3?" -v
 uv run -m app -m "List ArgoCD applications" -v
 
@@ -140,9 +140,12 @@ uv run -m app -m "LIST_AGENTS"
 
 ### Option A: Full Multi-Agent System
 
+**Attention**: Need to follow the following exact order: ensure to run agents first, then run Orchestrator so that agents can be detected by orchestrator, lastly run orchestrate client for interactive QA.
+
 **Terminal 1: Currency Agent**
 ```bash
 cd currencyAgent
+export GOOGLE_API_KEY=your_google_api_key
 uv run -m app
 ```
 
@@ -173,7 +176,7 @@ cd orchestrator_client
 uv run . --agent http://localhost:8000
 
 # Try these routing examples:
-# > "Convert 100 USD to EUR"     → Currency Agent (100% confidence)
+# > "what is 10 USD to INR"     → Currency Agent (100% confidence)
 # > "What is 2+3?"               → Math Agent (95% confidence)
 # > "List all applications"      → ArgoCD Agent (100% confidence)
 ```

--- a/argocdAgent/pyproject.toml
+++ b/argocdAgent/pyproject.toml
@@ -5,7 +5,7 @@ description = "LangGraph ArgoCD agent with A2A Protocol and MCP integration"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "a2a-sdk>=0.2.6,<0.3.0",
+    "a2a-sdk==0.2.10",
     "aiohttp>=3.8.0",
     "click>=8.1.8",
     "httpx>=0.28.1",

--- a/currencyAgent/pyproject.toml
+++ b/currencyAgent/pyproject.toml
@@ -5,7 +5,7 @@ description = "Sample LangGraph currency agent with A2A Protocol"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "a2a-sdk>=0.2.6,<0.3.0",
+    "a2a-sdk==0.2.10",
     "click>=8.1.8",
     "httpx>=0.28.1",
     "langchain-google-genai>=2.0.10",

--- a/mathAgent/pyproject.toml
+++ b/mathAgent/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "A2A MCP Team"}
 ]
 dependencies = [
-    "a2a-sdk>=0.2.6,<0.3.0",
+    "a2a-sdk==0.2.10",
     "httpx>=0.25.0",
     "uvicorn>=0.23.0",
     "click>=8.0.0",
@@ -20,7 +20,7 @@ dependencies = [
     "sympy>=1.12",
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
-    "mcp>=1.0.0"
+    "mcp>=1.0.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -5,7 +5,6 @@ description = "A2A Orchestrator Agent using LangGraph for intelligent request ro
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk>=0.2.6,<0.3.0",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "httpx>=0.25.0",
@@ -13,6 +12,7 @@ dependencies = [
     "langgraph>=0.2.0",
     "langchain-core>=0.3.0",
     "typing-extensions>=4.5.0",
+    "a2a-sdk==0.2.10",
 ]
 
 [build-system]

--- a/orchestrator_client/pyproject.toml
+++ b/orchestrator_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "A command-line client for interacting with the A2A Orchestrator A
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "a2a-sdk",
+    "a2a-sdk==0.2.10",
     "asyncclick>=8.1.8",
     "sse-starlette>=2.2.1",
     "starlette>=0.46.1",


### PR DESCRIPTION
1. lock a2a-sdk version to 0.2.10 to avoid error like `ImportError: cannot import name 'InMemoryPushNotifier' from 'a2a.server.tasks'`
2. refine readme doc